### PR TITLE
Hotfixes

### DIFF
--- a/databroker_browser/qt/_core.py
+++ b/databroker_browser/qt/_core.py
@@ -5,6 +5,7 @@ import itertools
 import matplotlib
 from matplotlib.backends.qt_compat import QtWidgets, QtCore
 from matplotlib.figure import Figure
+import matplotlib.pyplot as plt
 
 
 CLIPBOARD = QtWidgets.QApplication.clipboard()
@@ -175,6 +176,8 @@ class HeaderViewerWidget:
         self.fig_dispatch = fig_dispatch
         self.text_dispatch = text_dispatch
         self._tabs = QtWidgets.QTabWidget()
+        self._tabs.setTabsClosable(True)
+        self._tabs.tabCloseRequested.connect(self.close_tab)
         self.widget = QtWidgets.QWidget()
         self._text_summary = QtWidgets.QLabel()
         self._tree = QtWidgets.QTreeWidget()
@@ -265,6 +268,14 @@ class HeaderViewerWidget:
         tab.setLayout(layout)
         self._tabs.addTab(tab, '{:.8}'.format(name))
         return fig
+
+    def close_tab(self, currentIndex):
+        w = self._tabs.widget(currentIndex)
+        w.deleteLater()
+        # Remove figure from registry so it will be re-made if needed later.
+        figname = self._figures.pop(list(self._figures)[currentIndex])
+        plt.close(figname)  # clean up figure
+        self._tabs.removeTab(currentIndex)
 
 
 class HeaderViewerWindow(HeaderViewerWidget):


### PR DESCRIPTION
* Fix show-stopping bug that was resulting from the databroker `Results` API change
* Truncate search results so that large searches don't hang the app. This is an "enhancement" I guess, but the app is not very useful at production beamlines without it.
* Make tabs closable. This an "enhancement" too, but long-lived apps would become unusable without out.