### PR TITLE
ENH: add BEC to the example of databroker-browser

### DIFF
--- a/example.py
+++ b/example.py
@@ -3,7 +3,7 @@
 
 
 from databroker_browser.qt import BrowserWindow, CrossSection, StackViewer
-from bluesky.callbacks.mpl_plotting import LivePlot
+from bluesky.callbacks.best_effort import BestEffortCallback
 
 
 search_result = lambda h: "{start[plan_name]} ['{start[uid]:.6}']".format(**h)
@@ -11,17 +11,8 @@ text_summary = lambda h: "This is a {start[plan_name]}.".format(**h)
 
 
 def fig_dispatch(header, factory):
-    if 'image_det' in header['start']['detectors']:
-        fig = factory('Image Series')
-        cs = CrossSection(fig)
-        StackViewer(cs, db.get_images(header, 'image'))
-    elif len(header['start'].get('motors', [])) == 1:
-        motor, = header['start']['motors']
-        main_det, *_ = header['start']['detectors']
-        fig = factory("{} vs {}".format(main_det, motor))
-        ax = fig.gca()
-        lp = LivePlot(main_det, motor, ax=ax)
-        db.process(header, lp)
+    bec = BestEffortCallback(fig_factory=factory, table_enabled=False)
+    db.process(header, bec)
 
 
 def browse():


### PR DESCRIPTION
Following @jrmlhermitte's enhancement of BEC (https://github.com/NSLS-II/bluesky/pull/967), here is an update of the corresponding example in the databroker browser.